### PR TITLE
Fix link to MDTraj

### DIFF
--- a/cheminformatics_resources.md
+++ b/cheminformatics_resources.md
@@ -60,7 +60,7 @@ This is a list of some of the Cheminformatics resources that I use.  Rather than
 
 [Prody](http://prody.csb.pitt.edu/) - Do you want to work with proteins in Python? Then Prody is the tool for you.  Prody provides tools for reading and processing proteins, as well as implementing techniques like normal mode analysis.  In addition to its many capabilities, Prody is well documented and comes with a ton of examples. 
 
-[MDTraj](http://prody.csb.pitt.edu/) - Do you want to be able to process molecular dynamics (MD) trajectories in Python scripts?  Look no further.  MDTraj can read most trajectory formats and provides a wide array of analysis tools.  Recent work has enabled integration with the RDKit and provided additional capabilities for combining proteins and small molecules in an analysis. 
+[MDTraj](https://www.mdtraj.org) - Do you want to be able to process molecular dynamics (MD) trajectories in Python scripts?  Look no further.  MDTraj can read most trajectory formats and provides a wide array of analysis tools.  Recent work has enabled integration with the RDKit and provided additional capabilities for combining proteins and small molecules in an analysis. 
 
 [ODDT](https://github.com/oddt/oddt) - The Open Drug Discovery Toolkit builds on the RDKit and/or OpenBabel to provide several useful capabilities including protein-ligand interaction fingerprints and a variety of scoring functions. 
 


### PR DESCRIPTION
Thanks for the nice list of resources! This PR fix the link to [MDTraj](https://mdtraj.org), which was linking to [Prody](http://prody.csb.pitt.edu/) instead.

On a different note: MDTraj is a really good library for the analysis of MD trajectories, however I couldn't find any link with RDKit in the repository or documentation. I might be totally wrong here, but were you maybe referring in the description to the [recent work in MDAnalysis](https://www.mdanalysis.org/2020/08/29/gsoc-report-cbouy/) presented at the RDKit UGM?